### PR TITLE
❍ Fixed d3 formatting for yAxis and tooltips ❍

### DIFF
--- a/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -39,14 +39,8 @@ import { DEFAULT_FORM_DATA } from './types';
 import { legendOrientationControl, legendTypeControl, showLegendControl } from '../controls';
 import { LABEL_POSITION } from '../constants';
 
-const {
-  labelType,
-  labelPosition,
-  numberFormat,
-  showLabels,
-  isCircle,
-  emitFilter,
-} = DEFAULT_FORM_DATA;
+const { labelType, labelPosition, numberFormat, showLabels, isCircle, emitFilter } =
+  DEFAULT_FORM_DATA;
 
 const radarMetricMaxValue: { name: string; config: ControlFormItemSpec } = {
   name: 'radarMetricMaxValue',
@@ -191,7 +185,8 @@ const config: ControlPanelConfig = {
                 [GenericDataType.NUMERIC]: [[radarMetricMaxValue]],
               },
               mapStateToProps(explore, control, chart) {
-                const values = (explore?.controls?.metrics?.value as QueryFormMetric[]) ?? [];
+                // TODO: try to do this with a loader later
+                const values = (explore?.controls?.metrics?.value as QueryFormMetric[]) || [];
                 const metricColumn = values.map(value => {
                   if (typeof value === 'string') {
                     return value;

--- a/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx
@@ -185,7 +185,6 @@ const config: ControlPanelConfig = {
                 [GenericDataType.NUMERIC]: [[radarMetricMaxValue]],
               },
               mapStateToProps(explore, control, chart) {
-                // TODO: try to do this with a loader later
                 const values = (explore?.controls?.metrics?.value as QueryFormMetric[]) || [];
                 const metricColumn = values.map(value => {
                   if (typeof value === 'string') {

--- a/plugins/plugin-chart-echarts/src/types.ts
+++ b/plugins/plugin-chart-echarts/src/types.ts
@@ -62,6 +62,8 @@ export type ProphetValue = {
   forecastTrend?: number;
   forecastLower?: number;
   forecastUpper?: number;
+  seriesType?: string;
+  seriesName?: string;
 };
 
 export type EchartsLegendFormData = {

--- a/plugins/plugin-chart-echarts/src/utils/prophet.ts
+++ b/plugins/plugin-chart-echarts/src/utils/prophet.ts
@@ -39,7 +39,7 @@ export const extractProphetValuesFromTooltipParams = (
 ): Record<string, ProphetValue> => {
   const values: Record<string, ProphetValue> = {};
   params.forEach(param => {
-    const { marker, seriesId, value } = param;
+    const { marker, seriesId, seriesName, seriesType, value } = param;
     const context = extractForecastSeriesContext(seriesId);
     const numericValue = (value as [Date, number])[1];
     if (numericValue) {
@@ -55,6 +55,13 @@ export const extractProphetValuesFromTooltipParams = (
         prophetValues.forecastLower = numericValue;
       if (context.type === ForecastSeriesEnum.ForecastUpper)
         prophetValues.forecastUpper = numericValue;
+
+      // used in tooltip to identify correct d3 formatting
+      values[context.name] = {
+        ...values[context.name],
+        seriesType,
+        seriesName,
+      };
     }
   });
   return values;


### PR DESCRIPTION
☐------------------------------☐
  ✸ Developer: Kazak0ff
  ✸ Date: Jul 6th [ 19:03:00 ]
☐------------------------------☐

🏆 Enhancements

In the `plugin-chart-echarts` plugin there is now a support for custom d3 formatting from dataset metrics.
- the yAxis(es) are now able to be formatted with d3 formatting from dataset metrics
- the tooltips are now able to be formatted with d3 formatting from dataset metrics

If there is a d3 formatting in the dataset metric configuration, the yAxis(es) and tooltip values are going to be displayed according to that d3 format

If **Primary y-axis format** and/or **Secondary y-axis format** is set, the d3 formatting has no affect on neither the tooltip nor yAxis(es)

P.S. There is a small fix in `plugins/plugin-chart-echarts/src/Radar/controlPanel.tsx`. This is a temporary measure so that superset-frontend can be deployed. Later it will be fixed on the compiler level in superset-ui.
PR reference: https://github.com/dodopizza/superset-ui/pull/1