### PR TITLE
❍ Added the ability to show values for series A, B ❍

### DIFF
--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/controlPanel.tsx
@@ -48,6 +48,8 @@ const {
   rowLimit,
   seriesType,
   stack,
+  showValuesA,
+  showValuesB,
   truncateYAxis,
   yAxisBounds,
   zoomable,
@@ -251,6 +253,30 @@ const config: ControlPanelConfig = {
         ['color_scheme', 'label_colors'],
         ...createCustomizeSection(t('Query A'), ''),
         ...createCustomizeSection(t('Query B'), 'B'),
+        [
+          {
+            name: 'showValuesA',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show values A'),
+              renderTrigger: true,
+              default: showValuesA,
+              description: t('Show values for the chart without hovering'),
+            },
+          },
+        ],
+        [
+          {
+            name: 'showValuesB',
+            config: {
+              type: 'CheckboxControl',
+              label: t('Show values B'),
+              renderTrigger: true,
+              default: showValuesB,
+              description: t('Show values for the chart without hovering'),
+            },
+          },
+        ],
         [
           {
             name: 'zoomable',

--- a/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/MixedTimeseries/types.ts
@@ -64,6 +64,8 @@ export type EchartsMixedTimeseriesFormData = {
   rowLimitB: number;
   seriesType: EchartsTimeseriesSeriesType;
   seriesTypeB: EchartsTimeseriesSeriesType;
+  showValuesA: boolean;
+  showValuesB: boolean;
   stack: boolean;
   stackB: boolean;
   yAxisIndex?: number;
@@ -101,6 +103,8 @@ export const DEFAULT_FORM_DATA: EchartsMixedTimeseriesFormData = {
   seriesType: TIMESERIES_DEFAULTS.seriesType,
   seriesTypeB: TIMESERIES_DEFAULTS.seriesType,
   stack: TIMESERIES_DEFAULTS.stack,
+  showValuesA: TIMESERIES_DEFAULTS.showValuesA,
+  showValuesB: TIMESERIES_DEFAULTS.showValuesB,
   stackB: TIMESERIES_DEFAULTS.stack,
   yAxisIndex: 0,
   yAxisIndexB: 0,

--- a/plugins/plugin-chart-echarts/src/Timeseries/types.ts
+++ b/plugins/plugin-chart-echarts/src/Timeseries/types.ts
@@ -54,6 +54,8 @@ export type EchartsTimeseriesFormData = {
   rowLimit: number;
   seriesType: EchartsTimeseriesSeriesType;
   stack: boolean;
+  showValuesA: boolean;
+  showValuesB: boolean;
   tooltipTimeFormat?: string;
   truncateYAxis: boolean;
   yAxisFormat?: string;
@@ -87,6 +89,8 @@ export const DEFAULT_FORM_DATA: EchartsTimeseriesFormData = {
   rowLimit: 10000,
   seriesType: EchartsTimeseriesSeriesType.Line,
   stack: false,
+  showValuesA: false,
+  showValuesB: false,
   tooltipTimeFormat: 'smart_date',
   truncateYAxis: true,
   yAxisBounds: [null, null],


### PR DESCRIPTION
☐-------------------------------☐
  ✸ Developer: Kazak0ff
  ✸ Date: Jul 15th [ 15:36:00 ]
☐-------------------------------☐

🏆 Enhancements
In the `plugin-chart-echarts` plugin there is now a support for showing values for series A, B 

The new control value SHOW VALUES A, SHOW VALUES B is added to chart options